### PR TITLE
Add links for alternate names to existing icons

### DIFF
--- a/apps/scalable/knotes.svg
+++ b/apps/scalable/knotes.svg
@@ -1,0 +1,1 @@
+accessories-text-editor.svg

--- a/apps/scalable/org.gimp.GIMP.svg
+++ b/apps/scalable/org.gimp.GIMP.svg
@@ -1,0 +1,1 @@
+gimp.svg

--- a/apps/scalable/ukuu.svg
+++ b/apps/scalable/ukuu.svg
@@ -1,0 +1,1 @@
+system-software-update.svg


### PR DESCRIPTION
So far:
- `org.gimp.GIMP` linked to `gimp`
- `knotes` linked to `accessories-text-editor`
- `ukuu` linked to `system-software-update`