### PR TITLE
Add link for Liferea icon

### DIFF
--- a/apps/scalable/net.sourceforge.liferea.svg
+++ b/apps/scalable/net.sourceforge.liferea.svg
@@ -1,0 +1,1 @@
+liferea.svg


### PR DESCRIPTION
Liferea 1.13.4 changed icon name, this PR add symlink for the new name.