### PR TITLE
Linking bluetooth icon

### DIFF
--- a/apps/scalable/bluetooth.svg
+++ b/apps/scalable/bluetooth.svg
@@ -1,0 +1,1 @@
+preferences-system-bluetooth.svg


### PR DESCRIPTION
Hello,
In Linux Mint there is a bluetooth app that uses an icon called bluetooth. Since it was missing, I added a link from preferences-system-bluetooth.svg