### PR TITLE
Set `FollowsColorScheme=true`

### DIFF
--- a/index.theme
+++ b/index.theme
@@ -3,6 +3,8 @@ Name=candy-icons
 Comment=Sweet gradient icons.
 Inherits=breeze-dark,gnome,ubuntu-mono-dark,Mint-X,elementary,gnome,hicolor
 
+FollowsColorScheme=true
+
 
 # Directory list
 Directories=places/16,places/48,apps/scalable,devices/scalable,preferences/scalable,mimetypes/scalable


### PR DESCRIPTION
Thank you for this astonishing beautiful icon theme.

I'm having some troubles with breeze icon colors when using candy-icons and sweet-folders, with dark icon colors over dark color scheme.

This PR adds `FollowsColorScheme=true` to fix Breeze inherit icon colors

### **candy-icons** without `FollowsColorScheme`

![Imgur](https://i.imgur.com/YNGNpA5.png)

### **Sweet-Rainbow** with `FollowColorScheme`

![Imgur](https://i.imgur.com/2rVwWzK.png)