### PR TITLE
Add links for cryptomator mimetypes

### DIFF
--- a/mimetypes/scalable/application-vnd.cryptomator.encrypted.svg
+++ b/mimetypes/scalable/application-vnd.cryptomator.encrypted.svg
@@ -1,0 +1,1 @@
+../../apps/scalable/org.cryptomator.Cryptomator.svg

--- a/mimetypes/scalable/application-vnd.cryptomator.vault.svg
+++ b/mimetypes/scalable/application-vnd.cryptomator.vault.svg
@@ -1,0 +1,1 @@
+../../apps/scalable/org.cryptomator.Cryptomator.svg


### PR DESCRIPTION
Mimetypes take from auto-generated appimage desktop entry : 

```
[Desktop Entry]
Name=Cryptomator
Comment=Cloud Storage Encryption Utility
#Icon=appimagekit_e96ddb4fe6d209ac0a0e2757707de32a_org.cryptomator.Cryptomator
Icon=org.cryptomator.Cryptomator
Terminal=false
Type=Application
Categories=Utility;Security;FileTools;
StartupNotify=true
StartupWMClass=org.cryptomator.launcher.Cryptomator$MainApp
MimeType=application/vnd.cryptomator.encrypted;application/vnd.cryptomator.vault;
X-AppImage-Old-Icon=org.cryptomator.Cryptomator
X-AppImage-Identifier=e96ddb4fe6d209ac0a0e2757707de32a
Actions=Remove;
X-AppImageLauncher-Version=2.2.0 (git commit 0f91801), built on 2022-04-22 02:10:10 UTC

[Desktop Action Remove]
Name=Remove AppImage from system
Icon=AppImageLauncher
```