### PR TITLE
Fix Brave icon

### DIFF
--- a/apps/scalable/com.brave.Browser.svg
+++ b/apps/scalable/com.brave.Browser.svg
@@ -1,0 +1,1 @@
+brave.svg


### PR DESCRIPTION
The icon for brave (flatpak version) does not work with this awesome icon pack.
Other apps like cura or vscodium have the same problem.
I can make an other pull request (if this one is merge) to correct that.
Have a good day.