### PR TITLE
create symbolic link for Strawberry flatpak

### DIFF
--- a/apps/scalable/org.strawberrymusicplayer.strawberry.svg
+++ b/apps/scalable/org.strawberrymusicplayer.strawberry.svg
@@ -1,0 +1,1 @@
+strawberry.svg


### PR DESCRIPTION
A symbolic link to make the icon from [the Strawberry music player request](https://github.com/EliverLara/candy-icons/issues/214) work with the version that is being distributed via [Flathub](https://flathub.org/apps/details/org.strawberrymusicplayer.strawberry).