### PR TITLE
Add missing symlink to rust file mimetype

### DIFF
--- a/mimetypes/scalable/text-rust.svg
+++ b/mimetypes/scalable/text-rust.svg
@@ -1,0 +1,1 @@
+text-x-rust.svg


### PR DESCRIPTION
This PR fixes the issue discussed in [#459](https://github.com/EliverLara/candy-icons/issues/459#issuecomment-1483736521) where the rust icon does not appear in some applications as the alternative mimetype `text/rust` (rather than `text/x-rust` is used. This is addressed by adding a symlink from `text-x-rust.svg` to `text-rust.svg`.