### PR TITLE
fix kde flatapk symlinks

### DIFF
--- a/apps/scalable/org.kde.okular.svg
+++ b/apps/scalable/org.kde.okular.svg
@@ -1,0 +1,1 @@
+apps/scalable/document-viewer.svg


### PR DESCRIPTION
This PR adds a symlink for KDE Okular's flatpak version. 