### PR TITLE
index.theme: remove nonexistent subdirs

### DIFF
--- a/index.theme
+++ b/index.theme
@@ -7,14 +7,6 @@ FollowsColorScheme=true
 # Directory list
 Directories=places/16,places/48,apps/scalable,devices/scalable,preferences/scalable,mimetypes/scalable
 
-
-[Apps]
-Context=Applications
-Size=96
-MinSize=8
-MaxSize=192
-Type=Scalable
-
 [apps/scalable]
 Size=96
 Context=Applications
@@ -36,14 +28,6 @@ MinSize=8
 MaxSize=512
 Type=Scalable
 
-
-[Mimes]
-Context=MimeTypes
-Size=96
-MinSize=8
-MaxSize=512
-Type=Scalable
-
 [mimetypes/scalable]
 Size=96
 Context=MimeTypes
@@ -58,44 +42,9 @@ MinSize=8
 MaxSize=32
 Type=Scalable
 
-
-[places/24]
-Size=24
-Context=Places
-Type=Scalable
-
 [places/48]
 Size=48
 Context=Places
 MinSize=8
 MaxSize=512
 Type=Scalable
-
-[Status]
-Context=Status
-Size=96
-MinSize=8
-MaxSize=512
-Type=Scalable
-
-[Categories]
-Context=Categories
-Size=96
-MinSize=8
-MaxSize=512
-Type=Scalable
-
-
-[Devices]
-Size=96
-Context=Devices
-Type=Scalable
-MinSize=8
-MaxSize=512
-
-[Emblems]
-Size=96
-Context=Emblems
-Type=Scalable
-MinSize=8
-MaxSize=512


### PR DESCRIPTION
Apps, Mimes, Status, Categories, Devices, Emblems, and places/24 are absent and not listed in Directories; this commit removes corresponding index.theme sections, improving icon theme specification compliance.