### PR TITLE
Use teams-for-linux icon for the new teams v2 pwa

### DIFF
--- a/apps/scalable/chrome-nfecgfopkdiicnnmccikafaofaoffegm-Default.svg
+++ b/apps/scalable/chrome-nfecgfopkdiicnnmccikafaofaoffegm-Default.svg
@@ -1,0 +1,1 @@
+teams-for-linux.svg


### PR DESCRIPTION
Hey,

This would add the icon for the ms teams v2 pwa.