### PR TITLE
Fix wrong link on osu-lazer icon

### DIFF
--- a/apps/scalable/osu-lazer.svg
+++ b/apps/scalable/osu-lazer.svg
@@ -1,1 +1,1 @@
-osmo.svg
+osu.svg


### PR DESCRIPTION
This issue was introduced in e00158648ec598cdec1375aac4f089ee4b2b7685