### PR TITLE
Fix zathura

### DIFF
--- a/apps/scalable/org.pwmt.zathura.svg
+++ b/apps/scalable/org.pwmt.zathura.svg
@@ -1,0 +1,1 @@
+zathura.svg


### PR DESCRIPTION
Currently, `zathura.svg` exists, but [desktop file](https://github.com/pwmt/zathura/blob/39361818f3c6a9651d0623d238a8248476a472a8/data/org.pwmt.zathura.desktop.in#L8) specifies `org.pwmt.zathura`.

I have added symlink from `zathura.svg` to `org.pwmt.zathura.svg`