### PR TITLE
Fix Localsend flatpak icon location

### DIFF
--- a/apps/scalable/org.localsend.localsend_app.svg
+++ b/apps/scalable/org.localsend.localsend_app.svg
@@ -1,0 +1,1 @@
+localsend.svg


### PR DESCRIPTION
The icon location for the flatpak version of LocalSend is different. (**org.localsend.localsend_app** instead of **localsend**).

So, I have created a simlink for the flatpak version.
