### PR TITLE
Add symlink for PrusaSlicer GCode Viewer Flatpak.

### DIFF
--- a/apps/scalable/com.prusa3d.PrusaSlicer.GCodeViewer.svg
+++ b/apps/scalable/com.prusa3d.PrusaSlicer.GCodeViewer.svg
@@ -1,0 +1,1 @@
+prusagcodeviewer.svg


### PR DESCRIPTION
Just added a symlink to the original PrusaSlicer GCode Viewer at  `apps/scalable/prusagcodeviewer.svg` for the flatpak version.

First PR, so I hope I've done this right :)