### PR TITLE
Remove broken symlink

### DIFF
--- a/places/16/folder-library.svg
+++ b/places/16/folder-library.svg
@@ -1,1 +1,0 @@
-/usr/share/icons/breeze-dark/places/16/folder-library.svg


### PR DESCRIPTION
Removes a broken symlink at `places/16/folder-library.svg`, which links to a file outside of the icon theme directory that may not necessarily exist.

Using `find . -xtype l`, I did not find any other broken symlinks.