### PR TITLE
Add new Thunderbird flatpak symlinks

### DIFF
--- a/apps/scalable/org.mozilla.thunderbird.svg
+++ b/apps/scalable/org.mozilla.thunderbird.svg
@@ -1,0 +1,1 @@
+thunderbird.svg

--- a/apps/scalable/org.mozilla.thunderbird_esr.svg
+++ b/apps/scalable/org.mozilla.thunderbird_esr.svg
@@ -1,0 +1,1 @@
+thunderbird.svg


### PR DESCRIPTION
[Per Mozilla's Channel Choices for Thunderbird Snap and Flatpak][1] page, as of 2026 the Thunderbird flatpak is now moving to two separate packages, named `org.mozilla.thunderbird` (distinct from the previous package due to the lowercase `T`), and `org.mozilla.thunderbird_esr`. This commit adds symlinks so these new names also use the thunderbird icon.

[1]: https://support.mozilla.org/en-US/kb/channel-choices-thunderbird-snap-and-flatpak#w_flatpak-beta-and-esr-changes-in-2026